### PR TITLE
added a layout predicate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 pyramid_layout changelog
 ========================
 
+next release
+------------
+
+- Added a layout predicate to make the selection of the layout manager
+  declarative when using Pyramid >= 1.4.
+
 0.4 (2012-08-21)
 ----------------
 

--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -6,18 +6,16 @@ from pyramid.view import view_config
     )
 @view_config(
     route_name='home.chameleon',
-    renderer='demo:templates/home.pt'
+    renderer='demo:templates/home.pt',
+    layout='chameleon'
     )
 @view_config(
     route_name='home.jinja2',
-    renderer='demo:templates/home.jinja2'
+    renderer='demo:templates/home.jinja2',
+    layout='jinja2'
     )
 def home(request):
     lm = request.layout_manager
-    if request.matched_route.name == 'home.chameleon':
-        lm.use_layout('chameleon')
-    if request.matched_route.name == 'home.jinja2':
-        lm.use_layout('jinja2')
     lm.layout.add_heading('heading-mako')
     lm.layout.add_heading('heading-chameleon')
     lm.layout.add_heading('heading-jinja2')

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -83,8 +83,15 @@ named::
                       'myproject.layout:templates/admin_layout.pt',
                       name='admin')
 
-Now that you have a layout, time to use it on a particular view. To use a named
-layout, call :meth:`LayoutManager.use_layout
+Now that you have a layout, time to use it on a particular view. Layouts can
+be defined declaratively, next to your renderer, in the view configuration::
+
+    @view_config(..., layout='admin')
+    def myview(context, request):
+        ...
+
+In Pyramid < 1.4, to use a named layout, call
+:meth:`LayoutManager.use_layout
 <pyramid_layout.layout.LayoutManager.use_layout>` method in your view::
 
     def myview(context, request):

--- a/pyramid_layout/config.py
+++ b/pyramid_layout/config.py
@@ -48,11 +48,28 @@ def create_layout_manager(event):
     request.layout_manager = lm
 
 
+class LayoutPredicate(object):
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'layout = %s' % self.val
+
+    phash = text
+
+    def __call__(self, context, request):
+        request.layout_manager.use_layout(self.val)
+        return True
+
+
 def includeme(config):
     config.add_directive('add_layout', add_layout)
     config.add_directive('add_panel', add_panel)
     config.add_subscriber(add_renderer_globals, BeforeRender)
     config.add_subscriber(create_layout_manager, ContextFound)
+
+    if hasattr(config, 'add_view_predicate'):
+        config.add_view_predicate('layout', LayoutPredicate)
 
 
 def add_panel(config, panel=None, name="", context=None,

--- a/pyramid_layout/tests/test_layout.py
+++ b/pyramid_layout/tests/test_layout.py
@@ -72,6 +72,22 @@ class LayoutManagerTests(unittest.TestCase):
         lookup.assert_called_once_with(
             (providedBy('context'),), IPanel, name='test')
 
+    @mock.patch('pyramid_layout.layout.find_layout')
+    def test_layout_predicate(self, find_layout):
+        from pyramid_layout.config import LayoutPredicate
+        lm = self.make_one('context', 'request')
+        find_layout.return_value = 'Test Layout'
+        pred = LayoutPredicate('test', None)
+        class Request(object):
+            pass
+        request = Request()
+        request.layout_manager = lm
+        result = pred(None, request)
+        self.assertTrue(result)
+        self.assertEqual(lm.layout, 'Test Layout')
+        self.assertEqual(pred.text(), 'layout = test')
+        find_layout.assert_called_once_with('context', 'request', 'test')
+
 
 class Test_find_layout(unittest.TestCase):
 


### PR DESCRIPTION
allows declarative selection of layouts so they can be tied more closely
to the renderer selection and view parameters

this feature uses pyramid 1.4's ability to add custom view predicates through a nifty api.. I made sure it falls back gracefully for older pyramids
