### PR TITLE
Better error handling for missing request and layout manager in add_renderer_globals

### DIFF
--- a/pyramid_layout/config.py
+++ b/pyramid_layout/config.py
@@ -28,14 +28,18 @@ except NameError:  #pragma no cover
 def add_renderer_globals(event):
     request = event['request']
     # if the rendering is done from a script or otherwise outside a
-    # regular request, the request will be None, so globals can't be set
-    if request is None:
-        return
-    layout_manager = request.layout_manager
-    layout = layout_manager.layout
-    event['layout'] = layout
-    event['main_template'] = layout.__template__
-    event['panel'] = layout_manager.render_panel
+    # regular request, the request will be None, so globals can't be set.
+    # also, the layout manager may not have been created due to runtime
+    # errors, but this event may still be fired -- this is caught to allow
+    # the original runtime error to surface in tracebacks.
+    try:
+      layout_manager = request.layout_manager
+      layout = layout_manager.layout
+      event['layout'] = layout
+      event['main_template'] = layout.__template__
+      event['panel'] = layout_manager.render_panel
+    except AttributeError:
+      pass
 
 
 def create_layout_manager(event):


### PR DESCRIPTION
`add_renderer_globals()` contains some logic that prevents runtime errors in the case where rendering is done from a script, but I found another case where more general error handling will benefit:
- The pyramid_debugtoolbar module is enabled.
- Route is matched via traversal.
- A runtime error occurs prior to the context being found.

In this case, `create_layout_manager()` is never called, but `add_renderer_globals()` is (because the debug toolbar is trying to return the runtime error via a request response, I think).

This is a real pain during development, because the traceback displayed when a runtime error occurs during the building of the context is something like:

```
  File "lib/python2.6/site-packages/pyramid_layout-0.4-py2.6.egg/pyramid_layout/config.py", line 35, in add_renderer_globals
    layout_manager = request.layout_manager
AttributeError: 'Request' object has no attribute 'layout_manager'
```

Not a terribly useful in this case. :)

The patch refactors the error handling in `add_renderer_globals()` in a more general manner, to support both the case of a missing request and a missing layout manager in the request.
