### PR TITLE
Add MANIFEST.in for setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt *.ini *.cfg *.rst
+recursive-include pyramid_layout *.mustache *.ext *.zcml


### PR DESCRIPTION
Setuptools requires it to include any package data (like ZCML files) that is not managed by CVS or Subversion.

http://pythonhosted.org/distribute/setuptools.html?highlight=include_package_data#new-and-changed-setup-keywords
