### PR TITLE
Pyramid-layout broken with pyramid-jinja2 >= 2.0

### DIFF
--- a/pyramid_layout/config.py
+++ b/pyramid_layout/config.py
@@ -43,8 +43,15 @@ def add_renderer_globals(event):
         layout = layout_manager.layout
         if layout is not None:
             template = layout.__template__
-            template = getattr(template, 'renderer', template)
-            template = getattr(template, 'template', template)
+            if hasattr(template, 'renderer'):
+                renderer = template.renderer
+                if hasattr(renderer, 'template'):
+                    template = renderer.template
+                elif hasattr(renderer, 'template_loader'):
+                    template = renderer.template_loader()
+                else:
+                    raise TypeError(u"Can not glean the template from {0}"
+                                    .format(renderer))
             event['layout'] = layout
             event['main_template'] = template
 


### PR DESCRIPTION
The template renderers from pyramid-jinja2 >-= 2.0 no longer have a `.template` attribute.
(Instead they have a callable `.template_loader`.)

I’m not absolutely certain that this is not a bug in pyramid-jinja2 rather than pyramid-layout. OTOH, so far as I can tell the only documented API for renderers (as of pyramid 1.5) is `__call__()`.
