### PR TITLE
DOC: layouts.rst: add .. code:: python

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -177,7 +177,9 @@ you can also register the panel declaratively::
                 if sibling is not context][:n_siblings]
 
 Like :term:`layouts <layout>`, :term:`panels <panel>` can also be registered
-for a context type::
+for a context type:
+
+.. code:: python
 
     from pyramid_layout.panel import panel_config
 


### PR DESCRIPTION
This code block is rendering without Python highlighting.

... must be a Pygments thing.

... It looks like GitHub does not do syntax autodetection (or maybe doesn't default to Python syntax for `::` blocks)::
- Web: https://pyramid-layout.readthedocs.org/en/latest/layouts.html#using-panels
- Original: https://github.com/Pylons/pyramid_layout/blob/ef9d35b163464db5d03ec80266b56c174d674f2b/docs/layouts.rst
- After this PR: https://github.com/westurner/pyramid_layout/blob/d3996b363fccd7d8b4f170317e04dd02ee7c9383/docs/layouts.rst
