### PR TITLE
Change venusian callback to category 'pyramid'

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,14 +40,14 @@ jobs:
         name: Validate coverage
         steps:
             - uses: actions/checkout@v2
-            - name: Setup python 3.9
+            - name: Setup python 3.13
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: 3.13
                   architecture: x64
 
             - run: pip install tox
-            - run: tox -e py27,py39,coverage
+            - run: tox -e py313,coverage
 #    docs:
 #        runs-on: ubuntu-latest
 #        name: Build the documentation

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,13 +14,10 @@ jobs:
         strategy:
             matrix:
                 py:
-                    - "2.7"
-                    - "3.6"
-                    - "3.7"
-                    - "3.8"
-                    - "3.9"
-                    - "pypy-2.7"
-                    - "pypy3"
+                    - "3.10"
+                    - "3.11"
+                    - "3.12"
+                    - "3.13"
                 os:
                     - "ubuntu-latest"
                 architecture:

--- a/pyramid_layout/layout.py
+++ b/pyramid_layout/layout.py
@@ -109,7 +109,7 @@ class layout_config(object):
             config = context.config.with_package(info.module)
             config.add_layout(layout=ob, **settings)
 
-        info = venusian.attach(wrapped, callback, category='pyramid_layout')
+        info = venusian.attach(wrapped, callback, category='pyramid')
 
         settings['_info'] = info.codeinfo # fbo "action_method"
         return wrapped

--- a/pyramid_layout/panel.py
+++ b/pyramid_layout/panel.py
@@ -33,7 +33,7 @@ class panel_config(object):
             config = context.config.with_package(info.module)
             config.add_panel(panel=ob, **settings)
 
-        info = venusian.attach(wrapped, callback, category='pyramid_layout')
+        info = venusian.attach(wrapped, callback, category='pyramid')
 
         if info.scope == 'class':
             # if the decorator was attached to a method in a class, or

--- a/pyramid_layout/tests/test_layout.py
+++ b/pyramid_layout/tests/test_layout.py
@@ -128,7 +128,7 @@ class Test_layout_config(unittest.TestCase):
         self.assertEqual(decorator('wrapped'), 'wrapped')
         info = venusian.attach.return_value
         args, kwargs = venusian.attach.call_args
-        self.assertEqual(kwargs, {'category': 'pyramid_layout'})
+        self.assertEqual(kwargs, {'category': 'pyramid'})
         wrapped, callback = args
         self.assertEqual(wrapped, 'wrapped')
         context = mock.Mock()

--- a/pyramid_layout/tests/test_panel.py
+++ b/pyramid_layout/tests/test_panel.py
@@ -22,7 +22,7 @@ class Test_panel_config(unittest.TestCase):
             decorator = fut(name='howdy')
             self.assertEqual(decorator(panel), panel)
             args, kw = venusian.attach.call_args
-            self.assertEqual(kw, {'category': 'pyramid_layout'})
+            self.assertEqual(kw, {'category': 'pyramid'})
             venusian_wrapped, callback = args
             self.assertEqual(venusian_wrapped, panel)
             config_context = mock.Mock()
@@ -48,7 +48,7 @@ class Test_panel_config(unittest.TestCase):
             decorator = fut()
             self.assertEqual(decorator(panel), panel)
             args, kw = venusian.attach.call_args
-            self.assertEqual(kw, {'category': 'pyramid_layout'})
+            self.assertEqual(kw, {'category': 'pyramid'})
             venusian_wrapped, callback = args
             self.assertEqual(venusian_wrapped, panel)
             config_context = mock.Mock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py36,py37,py38,py39,pypy27,pypy3,coverage
+    py311,py312,py313,coverage
 
 [testenv]
 extras =


### PR DESCRIPTION
Changed the category of the venusian callback to 'pyramid' as pyramid 2.0 only calls callbacks with category='pyramid' by default.

Michael Merickel explained the change:
My main reason for changing it is that each scan() does have a contract with the decorator that needs to be satisfied. All pyramid-compatible decorators expect the scanner to have a "config" attribute that is a Pyramid Configurator object. That is the contract you get when you use "config.scan()". So if a decorator wants the config object, shouldn't it register as the "pyramid" category or another custom category passed to scan to guarantee it gets what it needs? This seems to be the only safe way to do it with the scan api that is an umbrella search through the code.

If you see the category as a way to specify requirements to the callback, pyramid_layout should use 'pyramid' as well as it requires the config object to be there as well 